### PR TITLE
:bug: fix Interactive Template structure

### DIFF
--- a/nonebot/adapters/feishu/message.py
+++ b/nonebot/adapters/feishu/message.py
@@ -91,11 +91,10 @@ class MessageSegment(BaseMessageSegment["Message"]):
             "interactive",
             {
                 "type": "template",
-                "data":
-                {
+                "data": {
                     "template_id": template_id,
                     "template_variable": template_variable,
-                }
+                },
             },
         )
 

--- a/nonebot/adapters/feishu/message.py
+++ b/nonebot/adapters/feishu/message.py
@@ -90,8 +90,12 @@ class MessageSegment(BaseMessageSegment["Message"]):
         return InteractiveTemplate(
             "interactive",
             {
-                "template_id": template_id,
-                "template_variable": template_variable,
+                "type": "template",
+                "data":
+                {
+                    "template_id": template_id,
+                    "template_variable": template_variable,
+                }
             },
         )
 


### PR DESCRIPTION
The content structure when sending a interactive template has changed somehow, and keep using the old content structure can cause a error 400 with code 230099.
![image](https://github.com/nonebot/adapter-feishu/assets/60840908/e8df4b72-da76-45b8-8ca8-fbcdff299966)
