### PR TITLE
:memo: Docs: 修复文档中的示例插件

### DIFF
--- a/website/docs/guide/setup.md
+++ b/website/docs/guide/setup.md
@@ -127,7 +127,8 @@ http://$HOST:$PORT/feishu/$app_id
 ```python
 from nonebot.plugin import on_command
 from nonebot.typing import T_State
-from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent
+from nonebot.params import CommandArg
+from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent, Message
 
 helper = on_command("say")
 

--- a/website/versioned_docs/version-2.6.0/guide/setup.md
+++ b/website/versioned_docs/version-2.6.0/guide/setup.md
@@ -127,7 +127,8 @@ http://$HOST:$PORT/feishu/$app_id
 ```python
 from nonebot.plugin import on_command
 from nonebot.typing import T_State
-from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent
+from nonebot.params import CommandArg
+from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent, Message
 
 helper = on_command("say")
 

--- a/website/versioned_docs/version-2.6.1/guide/setup.md
+++ b/website/versioned_docs/version-2.6.1/guide/setup.md
@@ -127,7 +127,8 @@ http://$HOST:$PORT/feishu/$app_id
 ```python
 from nonebot.plugin import on_command
 from nonebot.typing import T_State
-from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent
+from nonebot.params import CommandArg
+from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent, Message
 
 helper = on_command("say")
 

--- a/website/versioned_docs/version-2.6.2/guide/setup.md
+++ b/website/versioned_docs/version-2.6.2/guide/setup.md
@@ -127,7 +127,8 @@ http://$HOST:$PORT/feishu/$app_id
 ```python
 from nonebot.plugin import on_command
 from nonebot.typing import T_State
-from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent
+from nonebot.params import CommandArg
+from nonebot.adapters.feishu import Bot as FeishuBot, MessageEvent, Message
 
 helper = on_command("say")
 


### PR DESCRIPTION
原先文档中的实例插件无法正常运行，终端中提示事件处理流程已完成但机器人无响应。通过排查后发现是某些类没有 import 导致的。现将其加上以确保能正常运行。